### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     name: Unit tests + coverage gate


### PR DESCRIPTION
Potential fix for [https://github.com/Noooste/garage-ui/security/code-scanning/2](https://github.com/Noooste/garage-ui/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/test.yml` so both `unit` and `smoke` jobs inherit minimal token rights.  
Best fix without changing behavior: set:

- `contents: read`

This supports `actions/checkout` and keeps default token scope minimal. Place it at workflow root (after `on:` block and before `jobs:`), so all jobs are covered consistently with one change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
