### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     name: Unit tests + coverage gate


### PR DESCRIPTION
Potential fix for [https://github.com/Noooste/garage-ui/security/code-scanning/1](https://github.com/Noooste/garage-ui/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/test.yml` so all jobs inherit minimal token access by default.  
Best single fix without changing functionality: set:

- `contents: read` (minimal baseline for checkout and repository reads)

Place it at workflow root (after `on:` block and before `jobs:`), so both `unit` and `smoke` jobs are covered consistently. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
