### PR TITLE
fix: Enables Garage UI to function correctly in IPv6-first and IPv6-only environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN addgroup -g 1000 garageui && \
     adduser -D -u 1000 -G garageui garageui
 
 COPY --from=backend-builder --chown=garageui:garageui /app/garage-ui .
-COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
+COPY --from=frontend-builder --chown=garageui:garageui /app/frontend/dist ./frontend/dist
 
 USER garageui
 
@@ -58,4 +58,3 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
 
 CMD ["./garage-ui"]
-

--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ garage:
   region: "garage"
 ```
 
+Server bind host is configured by `server.host` (default: `::`). IPv6 literals like `::` and `::1` are supported.
+
+```yaml
+server:
+  host: "::" # IPv6 wildcard (dual-stack-preferred)
+  port: 8080
+```
+
+If your environment needs explicit IPv4-only binding, set `server.host: "0.0.0.0"`.
+
 See [config.example.yaml](config.example.yaml) for all options including authentication, CORS, and logging.
 
 ### Environment Variables

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -160,7 +162,7 @@ func Load(configPath string, opts ...LoadOption) (*Config, error) {
 	viper.SetConfigType("yaml")
 
 	// Built-in defaults (lowest priority)
-	viper.SetDefault("server.host", "0.0.0.0")
+	viper.SetDefault("server.host", "::")
 	viper.SetDefault("server.port", 8080)
 	viper.SetDefault("server.environment", "production")
 	viper.SetDefault("garage.force_path_style", true)
@@ -383,7 +385,7 @@ func (c *Config) Validate() error {
 
 // GetAddress returns the full server address (host:port)
 func (c *Config) GetAddress() string {
-	return fmt.Sprintf("%s:%d", c.Server.Host, c.Server.Port)
+	return net.JoinHostPort(c.Server.Host, strconv.Itoa(c.Server.Port))
 }
 
 // IsDevelopment returns true if running in development mode

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -83,6 +83,9 @@ func TestLoad_EnvOnly_MissingFile(t *testing.T) {
 	if cfg.Server.Port != 9090 {
 		t.Errorf("Server.Port = %d, want 9090 (from env)", cfg.Server.Port)
 	}
+	if cfg.Server.Host != "::" {
+		t.Errorf("Server.Host = %q, want :: (default)", cfg.Server.Host)
+	}
 	if cfg.Garage.AdminToken != "env-token" {
 		t.Errorf("Garage.AdminToken = %q, want env-token", cfg.Garage.AdminToken)
 	}
@@ -367,6 +370,8 @@ func TestGetAddress(t *testing.T) {
 	}{
 		{"localhost", 8080, "localhost:8080"},
 		{"0.0.0.0", 80, "0.0.0.0:80"},
+		{"::", 80, "[::]:80"},
+		{"::1", 443, "[::1]:443"},
 		{"", 443, ":443"},
 	}
 	for _, tc := range tests {

--- a/backend/main.go
+++ b/backend/main.go
@@ -219,11 +219,12 @@ func main() {
 		addr := cfg.GetAddress()
 		logger.Info().
 			Str("address", addr).
+			Str("network", fiber.NetworkTCP).
 			Str("health_endpoint", fmt.Sprintf("http://%s/health", addr)).
 			Str("api_docs", fmt.Sprintf("http://%s/api/v1/", addr)).
 			Msg("Server starting")
 
-		if err := app.Listen(addr); err != nil {
+		if err := app.Listen(addr, fiber.ListenConfig{ListenerNetwork: fiber.NetworkTCP}); err != nil {
 			logger.Fatal().Err(err).Msg("Failed to start server")
 		}
 	}()

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,7 +2,7 @@
 
 # Server configuration
 server:
-  host: "0.0.0.0"
+  host: "::" # IPv6 wildcard; dual-stack behavior depends on OS/runtime socket settings
   port: 8080
   environment: "development" # development, production
   domain: "localhost" # Domain name for the application

--- a/helm/garage-ui/values.schema.json
+++ b/helm/garage-ui/values.schema.json
@@ -69,8 +69,8 @@
           "properties": {
             "host": {
               "type": "string",
-              "description": "Network interface to bind to (0.0.0.0 for all interfaces)",
-              "default": "0.0.0.0"
+              "description": "Network interface to bind to (use :: for IPv6 wildcard / dual-stack-preferred, or 0.0.0.0 for IPv4 wildcard)",
+              "default": "::"
             },
             "port": {
               "type": "integer",

--- a/helm/garage-ui/values.yaml
+++ b/helm/garage-ui/values.yaml
@@ -36,7 +36,7 @@ extraObjects: []
 
 config:
   server:
-    host: "0.0.0.0"
+    host: "::"
     port: 8080
     environment: "production"
     domain: "garage-ui.example.com"


### PR DESCRIPTION
This is a minor patch to allow Garage UI to bind to both IPv6 and IPv4 addresses, thus enabling it to run successfully in IPv6-only or IPv6-first environments. (I, myself, run an IPv6-first Kubernetes cluster, so I find myself needing this quite frequently).

It changes the binding default from "0.0.0.0" to "::", which works appropriately on IPv6 environments, dual-stack environments, and IPv4 environments (_if_ those IPv4-only environments understand IPv6 kernelwise, which in my experience is the majority of IPv4-only environments).

It also includes documentation updates which cover this and how to use 0.0.0.0 for strict IPv4-only binding.
