### PR TITLE
fix(frontend): align three-dot menu item icon spacing and text alignment

### DIFF
--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -151,7 +151,7 @@ const DropdownMenuItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<H
       <div
         ref={ref}
         className={cn(
-          'relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none',
+          'relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0',
           className
         )}
         onClick={(e) => {

--- a/frontend/src/pages/AccessControl.tsx
+++ b/frontend/src/pages/AccessControl.tsx
@@ -635,7 +635,7 @@ export function AccessControl() {
                                   setDeleteDialogOpen(true);
                                 }}
                               >
-                                <Trash2 className="mr-2 h-4 w-4" />
+                                <Trash2 className="h-4 w-4" />
                                 Delete
                               </DropdownMenuItem>
                             </DropdownMenuContent>


### PR DESCRIPTION
Before:
<img width="270" height="178" alt="image" src="https://github.com/user-attachments/assets/1d582c77-cca1-4837-9201-67444f74b3ff" />


After:
<img width="297" height="193" alt="image" src="https://github.com/user-attachments/assets/3a8ea342-5744-480d-bd42-bd5498554dab" />
