### PR TITLE
fix(frontend): bucket usage chart tooltip text color

### DIFF
--- a/frontend/src/components/charts/BucketUsageChart.tsx
+++ b/frontend/src/components/charts/BucketUsageChart.tsx
@@ -56,7 +56,7 @@ export function BucketUsageChart({ data }: BucketUsageChartProps) {
         <Tooltip
           formatter={(value) => formatBytes(value as number)}
           contentStyle={tooltipStyle as React.CSSProperties}
-          labelStyle={{ color: textColor }}
+          itemStyle={{ color: textColor }}
         />
         <Legend wrapperStyle={{ color: textColor }} />
       </PieChart>


### PR DESCRIPTION
Simple fix to the small problem.

Before fix
<img width="709" height="427" alt="Screenshot_20260816_203638" src="https://github.com/user-attachments/assets/dee407d6-ab0d-4027-8aa8-3067c2262190" />

After fix
<img width="704" height="429" alt="Screenshot_20260816_203858" src="https://github.com/user-attachments/assets/ab759fc6-3fad-43d1-863b-6e74193e65c0" />
