### PR TITLE
docs: fix logging format example options

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -148,4 +148,4 @@ cors:
 # The application uses zerolog for structured logging
 logging:
   level: "info" # Options: debug, info, warn, error
-  format: "text" or "json"
+  format: "text" # Options: text or json


### PR DESCRIPTION
I tried copying config.example.yaml and got an error as follows:
`Failed to load configuration error="error reading config file: While parsing config: yaml: line 149: did not find expected key" config_path=config.yaml`. Turns out someone has reported the issue here:  #113 

I updated the example to use `"text"` as default. Not sure which one should be the default though, lmk if the default needs to be changed.