### PR TITLE
fix(frontend): unify and polish UI layout

### DIFF
--- a/frontend/src/components/buckets/BucketListView.tsx
+++ b/frontend/src/components/buckets/BucketListView.tsx
@@ -93,7 +93,7 @@ export function BucketListView({
                   <TableCell className="font-medium max-w-[200px]">
                     <span className="truncate">{bucket.name}</span>
                     {bucket.websiteAccess && (
-                      <Badge variant="neutral" className="text-xs ml-2">
+                      <Badge variant="neutral" className="ml-2">
                         <Globe className="h-3 w-3 mr-1" />
                         Website
                       </Badge>

--- a/frontend/src/components/buckets/ObjectBrowserView.tsx
+++ b/frontend/src/components/buckets/ObjectBrowserView.tsx
@@ -269,7 +269,7 @@ export function ObjectBrowserView({
         </div>
 
         {/* Toolbar */}
-        <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-3">
+        <div className="flex flex-col lg:flex-row items-stretch lg:items-center justify-between gap-3">
           <div className="flex flex-1 items-center gap-2 max-w-full sm:max-w-md">
             <div className="relative flex-1">
               <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
@@ -297,14 +297,15 @@ export function ObjectBrowserView({
             </Button>
           </div>
           <div className="flex items-center gap-2 flex-wrap">
-            {onDeleteMultipleObjects && selectedCount > 0 && (
+            {onDeleteMultipleObjects && (
               <Button
                 onClick={handleRequestBulkDelete}
-                title={`Delete ${selectedCount} selected item(s)`}
-                className="bg-transparent border border-red-500 text-red-500 hover:bg-red-500/5"
+                disabled={selectedCount === 0}
+                title={selectedCount === 0 ? 'Select items to delete' : `Delete ${selectedCount} selected item(s)`}
+                className="bg-transparent border border-red-500 text-red-500 hover:bg-red-500/5 flex-1 sm:flex-initial"
               >
                 <Trash className="h-4 w-4" />
-                Delete {selectedCount} item{selectedCount !== 1 ? 's' : ''}
+                <span className="hidden sm:inline">{selectedCount === 0 ? 'Delete' : `Delete ${selectedCount} item${selectedCount !== 1 ? 's' : ''}`}</span>
               </Button>
             )}
             {onUploadFiles && (

--- a/frontend/src/components/layout/bucket-detail-shell.tsx
+++ b/frontend/src/components/layout/bucket-detail-shell.tsx
@@ -52,7 +52,7 @@ export function BucketDetailShell() {
     <div className="flex flex-col">
       {/* Hero */}
       <section className="px-7 pt-6 pb-5">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div className="flex min-w-0 items-start gap-3">
             <IconTile icon={<Database />} tone="primary" size="lg" />
             <div className="min-w-0">

--- a/frontend/src/components/layout/layout.tsx
+++ b/frontend/src/components/layout/layout.tsx
@@ -44,7 +44,7 @@ export function Layout() {
       <Button
         variant="ghost"
         size="icon"
-        className="fixed left-3 top-3 z-50 md:hidden"
+        className="fixed left-3 top-3 z-50 md:hidden h-8 w-8"
         onClick={() => setSidebarOpen(!sidebarOpen)}
         aria-label="Toggle navigation"
       >

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -76,9 +76,9 @@ const DropdownMenuContent = React.forwardRef<HTMLDivElement, DropdownMenuContent
 
         let left = rect.left;
         if (align === 'end') {
-          left = rect.right - 224; // 224px = w-56
+          left = rect.right - 176; // 176px = w-44
         } else if (align === 'center') {
-          left = rect.left + rect.width / 2 - 112; // 112px = half of w-56
+          left = rect.left + rect.width / 2 - 88; // 88px = half of w-44
         }
 
         setPosition({ left, ...placeUnder(rect, window.innerHeight, 8) });
@@ -124,7 +124,7 @@ const DropdownMenuContent = React.forwardRef<HTMLDivElement, DropdownMenuContent
           ...position,
         }}
         className={cn(
-          'z-50 w-56 origin-top-right overflow-auto rounded-md text-popover-foreground shadow-lg ring-1 ring-border border border-border focus:outline-none',
+          'z-50 w-44 origin-top-right overflow-auto rounded-md text-popover-foreground shadow-lg ring-1 ring-border border border-border focus:outline-none',
           className
         )}
         {...props}
@@ -161,7 +161,7 @@ DropdownMenuItem.displayName = 'DropdownMenuItem';
 
 const DropdownMenuSeparator = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('-mx-1 my-1 h-px bg-muted', className)} {...props} />
+    <div ref={ref} className={cn('my-1 h-px bg-muted', className)} {...props} />
   )
 );
 DropdownMenuSeparator.displayName = 'DropdownMenuSeparator';

--- a/frontend/src/pages/BucketPermissions.tsx
+++ b/frontend/src/pages/BucketPermissions.tsx
@@ -122,7 +122,7 @@ export function BucketPermissions() {
             </div>
           </div>
 
-          <div className="pt-1">
+          <div className="flex justify-end pt-1">
             <Button onClick={onGrant} disabled={!canSubmit}>
               {grant.isPending ? 'Granting…' : 'Grant access'}
             </Button>

--- a/frontend/src/pages/BucketSettings.tsx
+++ b/frontend/src/pages/BucketSettings.tsx
@@ -200,7 +200,7 @@ export function BucketSettings() {
                 control={control}
                 name="maxSizeEnabled"
                 render={({ field }) => (
-                  <label className="flex items-center gap-2 text-[14px]">
+                  <label className="flex w-full items-center gap-2 text-[14px]">
                     <Switch checked={field.value} onCheckedChange={field.onChange} />
                     <span>Limit total size</span>
                   </label>
@@ -210,7 +210,7 @@ export function BucketSettings() {
                 type="number"
                 min={1}
                 step={1}
-                className="w-32"
+                className="min-w-0 flex-1"
                 disabled={!watched.maxSizeEnabled}
                 {...register('maxSizeValue')}
               />
@@ -253,7 +253,7 @@ export function BucketSettings() {
                 control={control}
                 name="maxObjectsEnabled"
                 render={({ field }) => (
-                  <label className="flex items-center gap-2 text-[14px]">
+                  <label className="flex w-full items-center gap-2 text-[14px]">
                     <Switch checked={field.value} onCheckedChange={field.onChange} />
                     <span>Limit object count</span>
                   </label>
@@ -263,7 +263,7 @@ export function BucketSettings() {
                 type="number"
                 min={1}
                 step={1}
-                className="w-40"
+                className="min-w-0 flex-1"
                 disabled={!watched.maxObjectsEnabled}
                 {...register('maxObjectsValue')}
               />
@@ -281,17 +281,17 @@ export function BucketSettings() {
             )}
           </div>
 
-          <div className="flex items-center gap-3 border-t border-[var(--border)] pt-4">
-            <Button type="submit" disabled={!isDirty || isSubmitting}>
-              Save changes
-            </Button>
+          <div className="flex justify-end gap-2 border-t border-[var(--border)] pt-4">
             <Button
               type="button"
-              variant="ghost"
+              variant="secondary"
               onClick={() => reset(defaults)}
               disabled={!isDirty || isSubmitting}
             >
               Reset
+            </Button>
+            <Button type="submit" disabled={!isDirty || isSubmitting}>
+              Save changes
             </Button>
           </div>
         </form>

--- a/frontend/src/pages/BucketWebsite.tsx
+++ b/frontend/src/pages/BucketWebsite.tsx
@@ -138,9 +138,7 @@ export function BucketWebsite() {
               </div>
             </div>
           )}
-        </div>
-
-        <footer className="flex justify-end gap-2 border-t border-[var(--border)] bg-[var(--surface-sunken)] px-5 py-3">
+          <div className="flex justify-end gap-2 border-t border-[var(--border)] pt-4">
           <Button variant="secondary" onClick={handleReset} disabled={saving}>Reset</Button>
           <Button
             onClick={handleSave}
@@ -149,7 +147,8 @@ export function BucketWebsite() {
           >
             {saving ? 'Saving…' : disabling ? 'Disable website' : 'Save changes'}
           </Button>
-        </footer>
+          </div>
+        </div>
       </section>
     </div>
   );


### PR DESCRIPTION
## What/Why
Bucket pages use inconsistent responsive rules, footer styles, and action alignments. This PR unifies them so all pages share the same breakpoints, footer/divider pattern, button order and alignment, and menu widths on mobile, tablet, and desktop.

## Changes
- `bucket-detail-shell.tsx`, `ObjectBrowserView.tsx`: row layouts from `lg:` up; hero and toolbar stack below 1024px.
- `BucketSettings.tsx`: two-line quota rows with full-width inputs; Save/Reset row right-aligned, Reset on the left.
- `BucketWebsite.tsx`: footer replaced with the Quotas-style open divider; no `footer` tags remain.
- `BucketPermissions.tsx`: Grant access right-aligned.
- `dropdown-menu.tsx`: menus `w-56` → `w-44`; dropped `-mx-1` on separators fixing the inner horizontal scroll.
- `BucketListView.tsx`: dropped redundant `text-xs` on the Website badge so its height matches the Region badge.
- `ObjectBrowserView.tsx`: bulk-delete button is icon-only on mobile and stretches like Upload / Add Directory, always visible and disabled when nothing is selected.
- `layout.tsx`: hamburger button sized `h-8 w-8` to center exactly with the `h-14` top bar on mobile.

## Verification
Verified by building the Docker image successfully.